### PR TITLE
feat: 본문 미리보기 기능 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,10 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	runtimeOnly 'com.h2database:h2'
+	implementation 'com.h2database:h2'
 	compile group: 'org.springframework.boot', name: 'spring-boot-devtools', version: '2.2.1.RELEASE'
 	compile 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation group: 'org.jsoup', name: 'jsoup', version: '1.13.1'
 }
 
 test {

--- a/src/main/resources/templates/board/list.html
+++ b/src/main/resources/templates/board/list.html
@@ -55,14 +55,17 @@
 										</div>
 										<h3 class="heading"><a th:href="@{'/posts/' + ${board.id}}"><span th:text="${board.title}"
 																										 style="display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; width: 288px;"></span></a></h3>
-<!--										<div style="width: 288px; height:79px;"><span th:utext="${board.content}"-->
-<!--																					style="display: block; overflow: hidden; text-overflow: ellipsis; max-height: 100%; word-break: break-all"></span></div>-->
-										<div style="width: 288px; height:79px;"><div th:utext="${board.content}"
-																					  style="display: block; overflow: hidden; text-overflow: ellipsis; max-height: 100%; word-break: break-all"></div></div>
+
+										<div style="width: 288px; height:79px;">
+											<div th:with="content=${board.content}" th:text="${T(org.jsoup.Jsoup).parse(content).text()}"
+													style="display: block; overflow: hidden; text-overflow: ellipsis; max-height: 100%; word-break: break-all">
+											</div>
+										</div>
+
 										<div class="d-flex align-items-center mt-4 meta">
 <!--											<p class="mb-0"><a th:href="@{'/posts/' + ${board.id}}" class="btn btn-primary">Read More <span class="ion-ios-arrow-round-forward"></span></a></p>-->
 											<p class="ml-auto mb-0">
-												<a href="#" class="mr-2"><span th:text="${board.memberEntity.email}"></span></a>
+												<a href="#" class="mr-2"><span th:text="${board.memberEntity.name}"></span></a>
 <!--												<a href="#" class="meta-chat"><span class="icon-chat"></span> 3</a>-->
 												<span class="disqus-comment-count" th:data-disqus-identifier="${board.id}">0 Comments</span>
 <!--												<a th:href="@{'/posts/' + ${board.id}}#disqus_thread" data-disqus-identifier="${board.id}">Comments</a>-->


### PR DESCRIPTION
- th:utext로 표현할 땐 html 태그가 적용된 상태로 보여서 이미지 첨부하거나 밑줄 등을 설정하면 그대로 보여서 불편했음
- jsoup 라이브러리로 태그 없이 글자만 보이도록 변경 함

관련: #17